### PR TITLE
GitPod ng serve

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --proxy-config conf/proxy.conf.json",
+    "start": "ng serve --public-host 4200-${GITPOD_WORKSPACE_ID}.${GITPOD_WORKSPACE_CLUSTER_HOST} --proxy-config conf/proxy.conf.json",
     "build": "node --max_old_space_size=5048 ./node_modules/@angular/cli/bin/ng build --output-path=deployment/dist",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
Added the public-host attribute to the ng serve command to allow the frontend to work (read: be served) in GitPod.