### PR TITLE
security.txt

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Node.js version
         uses: actions/setup-node@v2
         with:
-          node-version: "16.x"
+          node-version: "20.x"
 
       - name: 'Generate unique docker tag to deploy'
         id: prep

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Node.js version
         uses: actions/setup-node@v2
         with:
-          node-version: "16.x"
+          node-version: "20.x"
 
       - name: 'Generate unique docker tag to deploy'
         id: prep

--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,7 @@
+Contact: mailto:devops-infra@ritense.com
+Contact: mailto:security@ritense.com
+Contact: mailto:info@ritense.com
+Expires: 2028-01-01T00:00:00.000Z
+Encryption: https://keys.openpgp.org/vks/v1/by-fingerprint/1DE9E228E98776FC7F0A1889D7F08227C45D59E3
+Preferred-Languages: en, nl
+Policy: https://github.com/valtimo-platform/valtimo-backend-libraries/security/policy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginxinc/nginx-unprivileged:1.27-alpine
 
 COPY --chown=1000:1000 ./deployment/dist /usr/share/nginx/html
+COPY --chown=1000:1000 .well-known/security.txt /usr/share/nginx/html/.well-known/security.txt
 COPY ./conf/default.conf /etc/nginx/conf.d/default.conf
 
 USER 1000


### PR DESCRIPTION
Added a Ritense security.txt, a convention for conveying guidance on how to report a security incident for security researchers. See https://securitytxt.org

This also implements one of the internet.nl recommendations, used by the Dutch government to check compliancy against modern internet standards.

The security.txt is deliberately not signed, as the recommendation is to sign with a canonical location in the file, which is impossible to know beforehand in the template. If an implementation wants a signed version, one can do so in the implementation itself.